### PR TITLE
Reintroduce volto-searchkit to BISE

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "volto-searchkit",
   "version": "1.0.0",
   "description": "EEA flavoured searchkit integration for Volto",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
- [x] Correct 'main' field in package.json
- [ ] my local configuration issue that should be easy to solve (browser receives files from `node_modules/.../volto-searchkit/...` while in the editor I have `src/addons/volto-searchkit/...`)
    - @tiberiuichim Maybe this is of interest: https://gist.github.com/silviubogan/af0219f8c02304e8b967adbc3461d621